### PR TITLE
Improve compatibility with Scala 2.13

### DIFF
--- a/src/it/scala/cafesat/it/ScriptRunner.scala
+++ b/src/it/scala/cafesat/it/ScriptRunner.scala
@@ -19,7 +19,7 @@ class Tests extends FunSuite with Matchers {
   val resourceDirHard = "src/it/resources/"
 
   def filesInResourceDir(dir : String, filter : String=>Boolean = all) : Iterable[File] = {    
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     val d = this.getClass.getClassLoader.getResource(dir)
     val asFile = if(d == null || d.getProtocol != "file") {
       // We are in Eclipse. The only way we are saved is by hard-coding the path               

--- a/src/it/scala/cafesat/it/ScriptRunner.scala
+++ b/src/it/scala/cafesat/it/ScriptRunner.scala
@@ -3,15 +3,15 @@ package it
 
 import scala.sys.process._
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import java.io.File
 import java.io.FileReader
 
 import parsers.Dimacs
 
-class Tests extends FunSuite with Matchers {
+class Tests extends AnyFunSuite with Matchers {
 
   private implicit val testingContext = Context(logger=util.SilentLogger)
 

--- a/src/main/scala/cafesat/Main.scala
+++ b/src/main/scala/cafesat/Main.scala
@@ -174,8 +174,6 @@ object Main {
     }
   }
 
-  private def splitList(lst: String) : Seq[String] = lst.split(':').map(_.trim).filter(!_.isEmpty)
-
   private def recursiveListFiles(f: File): Array[File] = {
     val these = f.listFiles
     these ++ these.filter(_.isDirectory).flatMap(recursiveListFiles)

--- a/src/main/scala/cafesat/Main.scala
+++ b/src/main/scala/cafesat/Main.scala
@@ -130,7 +130,7 @@ object Main {
 
 
 
-  def main(arguments: Array[String]) {
+  def main(arguments: Array[String]): Unit = {
     try {
       val (options0, trueArgs) = arguments.partition(str => str.startsWith("--"))
       val options = options0.map(str => str.substring(2))

--- a/src/main/scala/cafesat/StopWatch.scala
+++ b/src/main/scala/cafesat/StopWatch.scala
@@ -43,7 +43,7 @@ class StopWatch private (tag: String) {
   def seconds: Double = elapsed/1e9
   def nano: Long = elapsed
 
-  def reset() {
+  def reset() : Unit = {
     elapsed = 0
   }
 

--- a/src/main/scala/cafesat/api/Formulas.scala
+++ b/src/main/scala/cafesat/api/Formulas.scala
@@ -50,7 +50,7 @@ object Formulas {
     def ||(that: Formula): Formula = new Formula(Or(this.formula, that.formula))
 
     /** Returns the negation of `this`. */
-    def unary_!(): Formula = new Formula(Not(this.formula))
+    def unary_! : Formula = new Formula(Not(this.formula))
 
     /** Returns a formula representing the equivalence of `this` and `that`. */
     def iff(that: Formula): Formula = new Formula(Or(

--- a/src/main/scala/cafesat/asts/fol/Manip.scala
+++ b/src/main/scala/cafesat/asts/fol/Manip.scala
@@ -131,15 +131,23 @@ object Manip {
 
     def distribute(and1: Formula, and2: Formula): Formula = {
       val (And(fs1), And(fs2)) = (and1, and2)
-      And(fs1.flatMap{ case Or(fss1) =>
-        fs2.map{ case Or(fss2) => Or(fss1 ::: fss2) }
+      And(fs1.flatMap{
+        case Or(fss1) =>
+          fs2.map{
+            case Or(fss2) => Or(fss1 ::: fss2)
+            case _ => ???
+          }
+        case _ => ???
       })
     }
 
     def inductiveStep(f: Formula): Formula = f match {
       case And(fs) => fs match {
         case Nil => And(List(Or(List())))
-        case fs => And(fs.flatMap{ case And(fs2) => fs2 })
+        case fs => And(fs.flatMap{
+          case And(fs2) => fs2
+          case _ => ???
+        })
       }
       case Or(fs) => fs match {
         case Nil => And(List(Or(List())))
@@ -147,6 +155,7 @@ object Manip {
         case fs => And(
           fs.reduceLeft((and1, and2) => distribute(and1, and2)) match {
             case And(fs2) => fs2
+            case _ => ???
           }
         )
       }
@@ -155,6 +164,7 @@ object Manip {
           case Not(f) => Or(List(f))
           case f => Or(List(Not(f)))
         })
+        case _ => ???
       }))
 
       case PredicateApplication(_, _) | True() | False() => And(List(Or(List(f))))
@@ -257,8 +267,13 @@ object Manip {
 
     def distribute(or1: Formula, or2: Formula): Formula = {
       val (Or(fs1), Or(fs2)) = (or1, or2)
-      Or(fs1.flatMap{ case And(fss1) =>
-        fs2.map{ case And(fss2) => And(fss1 ::: fss2) }
+      Or(fs1.flatMap{
+        case And(fss1) =>
+          fs2.map{
+            case And(fss2) => And(fss1 ::: fss2)
+            case _ => ???
+          }
+        case _ => ???
       })
     }
 
@@ -285,7 +300,10 @@ object Manip {
     def inductiveStep(f: Formula): Formula = f match {
       case Or(fs) => fs match {
         case Nil => Or(List(And(List())))
-        case fs => Or(fs.flatMap{ case Or(fs2) => fs2 })
+        case fs => Or(fs.flatMap{
+          case Or(fs2) => fs2
+          case _ => ???
+        })
       }
       case And(fs) => fs match {
         case Nil => Or(List(And(List())))
@@ -293,6 +311,7 @@ object Manip {
         case fs => Or(
           fs.reduceLeft((or1, or2) => distribute(or1, or2)) match {
             case Or(fs2) => fs2
+            case _ => ???
           }
         )
       }
@@ -301,6 +320,7 @@ object Manip {
           case Not(f) => And(List(f))
           case f => And(List(Not(f)))
         })
+        case _ => ???
       }))
 
       case PredicateApplication(_, _) | True() | False()  => Or(List(And(List(f))))

--- a/src/main/scala/cafesat/common/FixedIntDoublePriorityQueue.scala
+++ b/src/main/scala/cafesat/common/FixedIntDoublePriorityQueue.scala
@@ -33,7 +33,7 @@ class FixedIntDoublePriorityQueue(val maxSize: Int) {
   }
 
   //careful, should not modify heap(0) since it is used by caller
-  private def siftUp(pos: Int, score: Double) {
+  private def siftUp(pos: Int, score: Double): Unit = {
     val element = heapElements(pos)
 
     var i = pos
@@ -50,7 +50,7 @@ class FixedIntDoublePriorityQueue(val maxSize: Int) {
     index(element) = i
   }
 
-  private def siftDown(pos: Int, score: Double) {
+   def siftDown(pos: Int, score: Double): Unit = {
     val element = heapElements(pos)
 
     var i = pos

--- a/src/main/scala/cafesat/common/FixedIntStack.scala
+++ b/src/main/scala/cafesat/common/FixedIntStack.scala
@@ -23,7 +23,7 @@ class FixedIntStack(maxSize: Int) {
   private val stack: Array[Int] = new Array(maxSize)
   private var topIndex: Int = -1
 
-  def push(el: Int) {
+  def push(el: Int): Unit = {
     topIndex += 1
     stack(topIndex) = el
   }

--- a/src/main/scala/cafesat/dpllt/DPLLSolver.scala
+++ b/src/main/scala/cafesat/dpllt/DPLLSolver.scala
@@ -463,7 +463,7 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
     private var maxLearnt: Int = nbClauses / 3
     private val maxLearntFactor: Double = 1.1
 
-    def augmentMaxLearnt() {
+    def augmentMaxLearnt(): Unit = {
       maxLearnt = (maxLearnt*maxLearntFactor + 1).toInt
     }
 
@@ -487,42 +487,42 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
     val vsidsQueue = new FixedIntDoublePriorityQueue(nbVar)
     initVSIDS()
 
-    def initVSIDS() {
+    def initVSIDS(): Unit = {
       originalClauses.foreach(cl => cl.lits.foreach(lit => {
         vsidsQueue.incScore(lit >> 1, vsidsInc)
       }))
     }
 
-    def incVSIDS(id: Int) {
+    def incVSIDS(id: Int): Unit = {
       val newScore = vsidsQueue.incScore(id, vsidsInc)
       if(newScore > 1e100)
         rescaleVSIDS()
     }
 
-    def rescaleVSIDS() {
+    def rescaleVSIDS(): Unit = {
       vsidsQueue.rescaleScores(1e-100)
       vsidsInc *= 1e-100
     }
 
-    def decayVSIDS() {
+    def decayVSIDS(): Unit = {
       vsidsInc *= vsidsDecay
     }
 
-    def incVSIDSClause(cl: Clause) {
+    def incVSIDSClause(cl: Clause): Unit = {
       cl.activity = cl.activity + vsidsClauseInc
       if(cl.activity > 1e100)
         rescaleVSIDSClause()
     }
-    def rescaleVSIDSClause() {
+    def rescaleVSIDSClause(): Unit = {
       for(cl <- learntClauses)
         cl.activity = cl.activity*1e-100
       vsidsClauseInc *= 1e-100
     }
-    def decayVSIDSClause() {
+    def decayVSIDSClause(): Unit = {
       vsidsClauseInc *= vsidsClauseDecay
     }
 
-    def learn(clause: Clause) {
+    def learn(clause: Clause): Unit = {
       assert(clause.size > 1)
 
       learntClauses ::= clause
@@ -541,7 +541,7 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
         reduceLearntClauses()
     }
 
-    def reduceLearntClauses() {
+    def reduceLearntClauses(): Unit = {
       val sortedLearntClauses = learntClauses.sortWith((cl1, cl2) => cl1.activity < cl2.activity)
       val (forgotenClauses, keptClauses) = sortedLearntClauses.splitAt(maxLearnt/2)
       learntClauses = keptClauses
@@ -562,12 +562,12 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
     override def toString: String = (learntClauses ++ originalClauses).mkString("{\n", "\n", "\n}")
   }
 
-  private[this] def recordClause(cl: Clause) {
+  private[this] def recordClause(cl: Clause): Unit = {
     watched(cl.lits(0)).append(cl)
     watched(cl.lits(1)).append(cl)
   }
 
-  private[this] def unrecordClause(cl: Clause) {
+  private[this] def unrecordClause(cl: Clause): Unit = {
     watched(cl.lits(0)).remove(cl)
     watched(cl.lits(1)).remove(cl)
   }
@@ -577,7 +577,7 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
    * even those returned as t-consequences. This makes the overall invariants
    * much easier to maintain and consistant.
    */
-  private[this] def enqueueLiteral(lit: Int, from: Clause = null) {
+  private[this] def enqueueLiteral(lit: Int, from: Clause = null): Unit = {
     logger.trace(
       "Enqueuing literal [" + literals(lit) + "] from clause: " +
       (if(from == null) "null" else from.lits.map(literals(_)).mkString("[", ", ", "]")))
@@ -597,7 +597,7 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
     levels(id) = decisionLevel
   }
 
-  private[this] def decide() {
+  private[this] def decide(): Unit = {
     if(cnfFormula.vsidsQueue.isEmpty) {
       logger.debug("VSIDS queue is empty, model found")
       status = Satisfiable
@@ -646,7 +646,7 @@ class DPLLSolver[T <: TheoryComponent](nbVars: Int, val theory: T)(implicit val 
     }
   }
 
-  private[this] def backtrack() {
+  private[this] def backtrack(): Unit = {
     if(decisionLevel == 0)
       status = Unsatisfiable
     else {

--- a/src/main/scala/cafesat/parsers/Dimacs.scala
+++ b/src/main/scala/cafesat/parsers/Dimacs.scala
@@ -37,7 +37,7 @@ object Dimacs {
     var nbVariables = 0
 
     val bufferInput = new BufferedReader(input)
-    val lines = Stream.continually(bufferInput.readLine()).takeWhile(_ != null)
+    val lines = LazyList.continually(bufferInput.readLine()).takeWhile(_ != null)
 
     for(line <- lines) {
       val length = line.size

--- a/src/main/scala/cafesat/sat/Literal.scala
+++ b/src/main/scala/cafesat/sat/Literal.scala
@@ -21,7 +21,7 @@ class Literal(private val id: Int, private var offset: Int, val polInt: Int, val
   // getId must be extended when there are more LiteralType
   def getID = id + offset
 
-  def setOffset(offset: Int) {
+  def setOffset(offset: Int): Unit = {
     this.offset = offset
   }
 

--- a/src/main/scala/cafesat/sat/Proof.scala
+++ b/src/main/scala/cafesat/sat/Proof.scala
@@ -62,15 +62,15 @@ class Proof(inputs: Set[Set[Literal]]) {
     while(!stack.isEmpty) {
       val inf = stack.top
       if(inferencesAdded.contains(inf))
-        stack.pop
+        stack.pop()
       else inf match {
         case InputInference(_) =>
-          stack.pop
+          stack.pop()
           buffer.append(inf)
           inferencesAdded += inf
         case ResolutionInference(_, left, right) =>
           if(inferencesAdded.contains(left) && inferencesAdded.contains(right)) {
-            stack.pop
+            stack.pop()
             buffer.append(inf)
             inferencesAdded += inf
           } else {

--- a/src/main/scala/cafesat/sat/Proof.scala
+++ b/src/main/scala/cafesat/sat/Proof.scala
@@ -35,7 +35,7 @@ class Proof(inputs: Set[Set[Literal]]) {
   //each inference is correct.
   //This code ensures that the inferences are already present in
   //the proof and make sure to reuse existing node as much as possible
-  def infer(left: Set[Literal], right: Set[Literal], concl: Set[Literal]) {
+  def infer(left: Set[Literal], right: Set[Literal], concl: Set[Literal]): Unit = {
     require(inferencesOpt == None)
     literalsToInferences.get(concl) match {
       case Some(_) =>
@@ -53,7 +53,7 @@ class Proof(inputs: Set[Set[Literal]]) {
    * This produces a compact array of ordored inferences, where
    * each premise of an inference is found earlier in the array.
    */
-  def linearize(conclusion: Set[Literal]) {
+  def linearize(conclusion: Set[Literal]): Unit = {
     require(inferencesOpt == None) 
     var buffer: ArrayBuffer[Inference] = new ArrayBuffer
     var inferencesAdded = new HashSet[Inference]

--- a/src/main/scala/cafesat/sat/Solver.scala
+++ b/src/main/scala/cafesat/sat/Solver.scala
@@ -84,7 +84,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
   private[this] val find1UIPStopWatch = StopWatch("backtrack.conflictanalysis.find1uip")
   private[this] val clauseMinimizationStopWatch = StopWatch("backtrack.conflictanalysis.clauseminimization")
 
-  def resetSolver() {
+  def resetSolver(): Unit = {
     nbConflicts = 0
     nbDecisions = 0
     nbPropagations = 0
@@ -110,7 +110,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     clauseMinimizationStopWatch.reset()
   }
 
-  def initClauses(clauses: List[Clause]) {
+  def initClauses(clauses: List[Clause]): Unit = {
     var newClauses: List[Clause] = Nil
     clauses.foreach(cl => {
       val litsUnique = cl.lits.toSet
@@ -367,7 +367,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     private var maxLearnt: Int = nbClauses / 3
     private val maxLearntFactor: Double = 1.1
 
-    def augmentMaxLearnt() {
+    def augmentMaxLearnt(): Unit = {
       maxLearnt = (maxLearnt*maxLearntFactor + 1).toInt
     }
 
@@ -391,42 +391,42 @@ class Solver(nbVars: Int)(implicit context: Context) {
     val vsidsQueue = new FixedIntDoublePriorityQueue(nbVar)
     initVSIDS()
 
-    def initVSIDS() {
+    def initVSIDS(): Unit = {
       originalClauses.foreach(cl => cl.lits.foreach(lit => {
         vsidsQueue.incScore(lit >> 1, vsidsInc)
       }))
     }
 
-    def incVSIDS(id: Int) {
+    def incVSIDS(id: Int): Unit = {
       val newScore = vsidsQueue.incScore(id, vsidsInc)
       if(newScore > 1e100)
         rescaleVSIDS()
     }
 
-    def rescaleVSIDS() {
+    def rescaleVSIDS(): Unit = {
       vsidsQueue.rescaleScores(1e-100)
       vsidsInc *= 1e-100
     }
 
-    def decayVSIDS() {
+    def decayVSIDS(): Unit = {
       vsidsInc *= vsidsDecay
     }
 
-    def incVSIDSClause(cl: Clause) {
+    def incVSIDSClause(cl: Clause): Unit = {
       cl.activity = cl.activity + vsidsClauseInc
       if(cl.activity > 1e100)
         rescaleVSIDSClause()
     }
-    def rescaleVSIDSClause() {
+    def rescaleVSIDSClause(): Unit = {
       for(cl <- learntClauses)
         cl.activity = cl.activity*1e-100
       vsidsClauseInc *= 1e-100
     }
-    def decayVSIDSClause() {
+    def decayVSIDSClause(): Unit = {
       vsidsClauseInc *= vsidsClauseDecay
     }
 
-    def learn(clause: Clause) {
+    def learn(clause: Clause): Unit = {
       assert(clause.size > 1)
 
       learntClauses ::= clause
@@ -445,7 +445,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
         reduceLearntClauses()
     }
 
-    def reduceLearntClauses() {
+    def reduceLearntClauses(): Unit = {
       val sortedLearntClauses = learntClauses.sortWith((cl1, cl2) => cl1.activity < cl2.activity)
       val (forgotenClauses, keptClauses) = sortedLearntClauses.splitAt(maxLearnt/2)
       learntClauses = keptClauses
@@ -466,18 +466,18 @@ class Solver(nbVars: Int)(implicit context: Context) {
     override def toString: String = (learntClauses ++ originalClauses).mkString("{\n", "\n", "\n}")
   }
 
-  private[this] def recordClause(cl: Clause) {
+  private[this] def recordClause(cl: Clause): Unit = {
     watched(cl.lits(0)).append(cl)
     watched(cl.lits(1)).append(cl)
   }
 
-  private[this] def unrecordClause(cl: Clause) {
+  private[this] def unrecordClause(cl: Clause): Unit = {
     watched(cl.lits(0)).remove(cl)
     watched(cl.lits(1)).remove(cl)
   }
 
 
-  private[this] def enqueueLiteral(lit: Int, from: Clause = null) {
+  private[this] def enqueueLiteral(lit: Int, from: Clause = null): Unit = {
     val id = lit >> 1
     val pol = (lit & 1) ^ 1
     assert(model(id) == -1)
@@ -494,7 +494,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     levels(id) = decisionLevel
   }
 
-  private[this] def decide() {
+  private[this] def decide(): Unit = {
     if(cnfFormula.vsidsQueue.isEmpty) {
       status = Satisfiable
     } else {
@@ -539,7 +539,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     }
   }
 
-  private[this] def backtrack() {
+  private[this] def backtrack(): Unit = {
     if(decisionLevel == 0)
       status = Unsatisfiable
     else {
@@ -592,7 +592,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
   }
 
 
-  private[this] def backtrackTo(lvl: Int) {
+  private[this] def backtrackTo(lvl: Int): Unit = {
     while(decisionLevel > lvl && !trail.isEmpty) {
       val head = trail.pop()
       decisionLevel = levels(head >> 1)
@@ -605,7 +605,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     decisionLevel = lvl
   }
 
-  private[this] def undo(lit: Int) {
+  private[this] def undo(lit: Int): Unit = {
     assert(isSat(lit))
     val id = lit>>1
     cnfFormula.vsidsQueue.insert(id)
@@ -618,7 +618,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     }
   }
 
-  private[this] def deduce() {
+  private[this] def deduce(): Unit = {
 
     while(qHead < trail.size) {
 
@@ -689,7 +689,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
   //some debugging assertions that can be introduced in the code to check for correctness
 
   //assert that there is no unit clauses in the database
-  def assertNoUnits() {
+  def assertNoUnits(): Unit = {
 
     assert(qHead == trail.size) //we assume that all unit clauses queued have been processed
 
@@ -703,7 +703,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
   }
 
   //assert the invariant of watched literal is correct
-  def assertWatchedInvariant() {
+  def assertWatchedInvariant(): Unit = {
     for(cl <- (cnfFormula.originalClauses ::: cnfFormula.learntClauses)) {
       if(!watched(cl.lits(0)).contains(cl)) {
         println("clause " + cl + " is not correctly watched on " + cl.lits(0))
@@ -733,7 +733,7 @@ class Solver(nbVars: Int)(implicit context: Context) {
     }
   }
 
-  def assertTrailInvariant() {
+  def assertTrailInvariant(): Unit = {
     val seen: Array[Boolean] = Array.fill(cnfFormula.nbVar)(false) // default value of false
     var lst: List[Int] = Nil
     var currentLevel = decisionLevel

--- a/src/main/scala/cafesat/sat/Vector.scala
+++ b/src/main/scala/cafesat/sat/Vector.scala
@@ -14,7 +14,7 @@ class Vector[A : ClassTag](initialSize: Int = 50) {
   def size = next
 
   /* Can be called manually for optimal performance */
-  def allocate(space: Int) {
+  def allocate(space: Int): Unit = {
     require(space > 0)
     val newSize = underlying.size + space
     val newArray = new Array[A](newSize)
@@ -22,31 +22,31 @@ class Vector[A : ClassTag](initialSize: Int = 50) {
     underlying = newArray
   }
 
-  def append(el: A) {
+  def append(el: A): Unit = {
     if(next >= underlying.size)
       allocate(underlying.size)
     underlying(next) = el
     next += 1
   }
 
-  def apply(i: Int) = {
+  def apply(i: Int): A = {
     require(i >= 0 && i < next)
     underlying(i)
   }
 
-  def update(i: Int, el: A) {
+  def update(i: Int, el: A): Unit = {
     require(i >= 0 && i < next)
     underlying(i) = el
   }
 
   /* Remove n last elements of the vector */
-  def shrink(n: Int) {
+  def shrink(n: Int): Unit = {
     require(n >= 0 && n <= size)
     next -= n        
   }
 
   /* Linear remove algorithm, requires to find el and shift remaining */
-  def remove(el: A) {
+  def remove(el: A): Unit = {
     var i = 0
     var j = 0
     while(i < next) {

--- a/src/main/scala/cafesat/theories/adt/AdtSolver.scala
+++ b/src/main/scala/cafesat/theories/adt/AdtSolver.scala
@@ -127,7 +127,7 @@ class AdtSolver {
   protected var instantiated      = new ArrayBuffer[Boolean]
 
   protected val potentialInst     = new mutable.HashSet[TermRef]
-  protected val downSet           = new mutable.ArrayStack[(TermRef, TermRef)]
+  protected val downSet           = new mutable.Stack[(TermRef, TermRef)]
 
   var debug = false
   var debug_didSplit = false
@@ -259,7 +259,7 @@ class AdtSolver {
         //TODO: selectee is head?
         val selectee = subTermRefs.head
         if (instantiated(selectee)) {
-          downSet.push(id, outEdges(selectee)(index0))
+          downSet.push((id, outEdges(selectee)(index0)))
         } else {
           selectorsOf.getOrElseUpdate(selectee, new mutable.HashMap) += (sort, ctor, index0) -> term
 //          potentialInst add id
@@ -488,7 +488,7 @@ class AdtSolver {
           val keysi = selectorsi.keySet
           val keysj = selectorsj.keySet
           for (key <- keysi intersect keysj)
-            downSet push (ref(selectorsi(key)), ref(selectorsj(key)))
+            downSet push ((ref(selectorsi(key)), ref(selectorsj(key))))
           for (key <- keysj diff keysi)
             selectorsi += key -> selectorsj(key)
           // FIXME: Why would we need this? Isn't it covered by label()?
@@ -499,13 +499,13 @@ class AdtSolver {
         case (Some(selectors), _) if esj.nonEmpty =>
           ctorOf(rj) match { case Some((sort, ctor)) =>
             for (((`sort`, `ctor`, index), sel) <- selectors)
-              downSet push (ref(sel), esj(index))
+              downSet push ((ref(sel), esj(index)))
           }
           selectorsOf.remove(ri)
         case (_, Some(selectors)) if esi.nonEmpty =>
           ctorOf(ri) match { case Some((sort, ctor)) =>
             for (((`sort`, `ctor`, index), sel) <- selectors)
-              downSet push (ref(sel), esi(index))
+              downSet push ((ref(sel), esi(index)))
           }
           // No need to remove selectors of rj, since ri will be the representative
 
@@ -580,7 +580,7 @@ class AdtSolver {
               })
             }
             val newConstructor = Constructor(sort, ctor, args.toList)
-            downSet push (t, registerTerm(newConstructor))
+            downSet push ((t, registerTerm(newConstructor)))
             // Kind of ugly, but we can only do this after registering the term:
             for ((index,v) <- freshVars) {
               val argSort = sig.argSort(sort, ctor, index)

--- a/src/main/scala/cafesat/theories/adt/AdtSolver.scala
+++ b/src/main/scala/cafesat/theories/adt/AdtSolver.scala
@@ -614,7 +614,7 @@ class AdtSolver {
     declaredTypes = inst.declaredTypes
 
     inst.allTopLevelTerms foreach registerTerm
-    sig.allDesignatedTerms foreach registerTerm
+    sig.allDesignatedTerms() foreach registerTerm
     printDebug(dumpTerms())
 
     // Actual algorithm
@@ -671,7 +671,7 @@ class AdtSolver {
               case Right(unsatReason) =>
                 lastUnsatReason = Some(unsatReason)
                 downSet.clear()
-                break
+                break()
               case _ =>
               //
             }
@@ -706,7 +706,7 @@ class AdtSolver {
                     case Right(unsatReason) =>
                       lastUnsatReason = Some(unsatReason)
                       downSet.clear()
-                      break
+                      break()
                     case _ =>
                     //
                   }

--- a/src/main/scala/cafesat/theories/adt/AdtSolver.scala
+++ b/src/main/scala/cafesat/theories/adt/AdtSolver.scala
@@ -497,15 +497,19 @@ class AdtSolver {
 
         // Merge selectors with children
         case (Some(selectors), _) if esj.nonEmpty =>
-          ctorOf(rj) match { case Some((sort, ctor)) =>
-            for (((`sort`, `ctor`, index), sel) <- selectors)
-              downSet push ((ref(sel), esj(index)))
+          ctorOf(rj) match {
+            case Some((sort, ctor)) =>
+              for (((`sort`, `ctor`, index), sel) <- selectors)
+                downSet push ((ref(sel), esj(index)))
+            case _ => ???
           }
           selectorsOf.remove(ri)
         case (_, Some(selectors)) if esi.nonEmpty =>
-          ctorOf(ri) match { case Some((sort, ctor)) =>
-            for (((`sort`, `ctor`, index), sel) <- selectors)
-              downSet push ((ref(sel), esi(index)))
+          ctorOf(ri) match {
+            case Some((sort, ctor)) =>
+              for (((`sort`, `ctor`, index), sel) <- selectors)
+                downSet push ((ref(sel), esi(index)))
+            case _ => ???
           }
           // No need to remove selectors of rj, since ri will be the representative
 

--- a/src/main/scala/cafesat/theories/adt/AdtSolver.scala
+++ b/src/main/scala/cafesat/theories/adt/AdtSolver.scala
@@ -637,7 +637,7 @@ class AdtSolver {
     //  (note difference between sort(v) vs. sort of tester)
     // FIXME: ACTUALLY, neither makes sense.
     inst.negtests foreach {case Tester(sort, ctor, t) =>
-      val ctorRefs = sig.ctorRefs(sort) - ctor
+      val ctorRefs = sig.ctorRefs(sort).diff(Set(ctor))
       val res = label(ref(t), sort, ctorRefs)
       if (res.isDefined)
         return Unsat(res.head)
@@ -772,13 +772,13 @@ class AdtSolver {
                 for (otherSort <- sig.sortRefs.reverseIterator if otherSort != sort)
                   pushState((r, otherSort, sig.ctorRefs(otherSort)))
                 if (sig.sorts(sort).size > 1)
-                  pushState((r, sort, sig.ctorRefs(sort) - ctor))
+                  pushState((r, sort, sig.ctorRefs(sort).diff(Set(ctor))))
                 (sort, ctor)
               case Some((sort, ctors)) =>
                 printDebug(s"\tsplitting on $r=<${niceTerm(r)}>: [$sort $ctors]")
                 val ctor = ctors.head
                 if (ctors.size > 1)
-                  pushState((r, sort, ctors - ctor))
+                  pushState((r, sort, ctors.diff(Set(ctor))))
                 (sort, ctor)
             }
             // Apply guessed labeling

--- a/src/main/scala/cafesat/theories/adt/AdtSolver.scala
+++ b/src/main/scala/cafesat/theories/adt/AdtSolver.scala
@@ -174,9 +174,9 @@ class AdtSolver {
     val _inEdges      = new ArrayBuffer[mutable.HashSet[TermRef]](inEdges.size) ++=
       inEdges.map(_.clone())
     val _sharedSets   = new mutable.HashMap[(TermRef, TermRef), mutable.HashSet[Index]] ++=
-      sharedSets.mapValues(_.clone())
+      sharedSets.view.mapValues(_.clone())
     val _selectorsOf  = new mutable.HashMap[TermRef, SelectorMap]() ++=
-      selectorsOf.mapValues(_.clone())
+      selectorsOf.view.mapValues(_.clone())
 
     val state = State(
       nextTermId, maxVarId,

--- a/src/test/scala/cafesat/api/ExtractorsSuite.scala
+++ b/src/test/scala/cafesat/api/ExtractorsSuite.scala
@@ -3,10 +3,10 @@ package cafesat.api
 import FormulaBuilder._
 import Extractors._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 
-class ExtractorsSuite extends FunSuite {
+class ExtractorsSuite extends AnyFunSuite {
 
   private val x1 = propVar()
   private val x2 = propVar()

--- a/src/test/scala/cafesat/api/FormulaBuilderSuite.scala
+++ b/src/test/scala/cafesat/api/FormulaBuilderSuite.scala
@@ -3,10 +3,10 @@ package cafesat.api
 import FormulaBuilder._
 import Solver._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 
-class FormulaBuilderSuite extends FunSuite {
+class FormulaBuilderSuite extends AnyFunSuite {
 
   private val x1 = propVar()
   private val x2 = propVar()

--- a/src/test/scala/cafesat/api/FormulasSuite.scala
+++ b/src/test/scala/cafesat/api/FormulasSuite.scala
@@ -3,10 +3,10 @@ package cafesat.api
 import FormulaBuilder._
 import Extractors._
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 
-class FormulasSuite extends FunSuite {
+class FormulasSuite extends AnyFunSuite {
 
   private val x1 = propVar()
   private val x2 = propVar()

--- a/src/test/scala/cafesat/common/FixedIntDoublePriorityQueueSuite.scala
+++ b/src/test/scala/cafesat/common/FixedIntDoublePriorityQueueSuite.scala
@@ -1,8 +1,8 @@
 package cafesat.common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class FixedIntDoublePriorityQueueSuite extends FunSuite {
+class FixedIntDoublePriorityQueueSuite extends AnyFunSuite {
 
 
   test("incScore and max") {

--- a/src/test/scala/cafesat/common/FixedIntStackSuite.scala
+++ b/src/test/scala/cafesat/common/FixedIntStackSuite.scala
@@ -1,8 +1,8 @@
 package cafesat.common
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class FixedIntStackSuite extends FunSuite {
+class FixedIntStackSuite extends AnyFunSuite {
 
   test("a new stack is empty") {
     val s = new FixedIntStack(5)

--- a/src/test/scala/cafesat/parsers/DimacsSuite.scala
+++ b/src/test/scala/cafesat/parsers/DimacsSuite.scala
@@ -3,11 +3,11 @@ package cafesat.parsers
 import java.io.Reader
 import java.io.StringReader
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.implicitConversions
 
-class DimacsSuite extends FunSuite {
+class DimacsSuite extends AnyFunSuite {
 
   private implicit def stringToInputReader(value: String): Reader = new StringReader(value)
 

--- a/src/test/scala/cafesat/sat/EvalSuite.scala
+++ b/src/test/scala/cafesat/sat/EvalSuite.scala
@@ -1,8 +1,8 @@
 package cafesat.sat
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class EvalSuite extends FunSuite {
+class EvalSuite extends AnyFunSuite {
 
   private val l1 = new Literal(0, true)
   private val l2 = new Literal(0, false)

--- a/src/test/scala/cafesat/sat/IncrementalSuite.scala
+++ b/src/test/scala/cafesat/sat/IncrementalSuite.scala
@@ -4,9 +4,9 @@ package sat
 import Solver.Results._
 import Solver.Clause
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class IncrementalSuite extends FunSuite {
+class IncrementalSuite extends AnyFunSuite {
 
   private implicit val emptyContext = Context(util.SilentLogger)
 

--- a/src/test/scala/cafesat/sat/InterpolationSuite.scala
+++ b/src/test/scala/cafesat/sat/InterpolationSuite.scala
@@ -1,8 +1,8 @@
 package cafesat.sat
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class InterpolationSuite extends FunSuite {
+class InterpolationSuite extends AnyFunSuite {
 
   private val a = new Literal(0, true)
   private val na = new Literal(0, false)

--- a/src/test/scala/cafesat/sat/ProofCheckerSuite.scala
+++ b/src/test/scala/cafesat/sat/ProofCheckerSuite.scala
@@ -1,8 +1,8 @@
 package cafesat.sat
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ProofCheckerSuite extends FunSuite {
+class ProofCheckerSuite extends AnyFunSuite {
 
   private val a = new Literal(0, true)
   private val na = new Literal(0, false)

--- a/src/test/scala/cafesat/sat/VectorSuite.scala
+++ b/src/test/scala/cafesat/sat/VectorSuite.scala
@@ -1,8 +1,8 @@
 package cafesat.sat
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class VectorSuite extends FunSuite {
+class VectorSuite extends AnyFunSuite {
 
   test("init with append") {
     val v1 = new Vector[Int](50)

--- a/src/test/scala/cafesat/theories/adt/AdtSolverIntListsTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverIntListsTests.scala
@@ -1,11 +1,11 @@
 package cafesat
 package theories.adt
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
-class AdtSolverIntListsTests extends FlatSpec with AdtSolverSpecHelpers {
+class AdtSolverIntListsTests extends AnyFlatSpec with AdtSolverSpecHelpers {
 
   import Types._
 

--- a/src/test/scala/cafesat/theories/adt/AdtSolverIntsTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverIntsTests.scala
@@ -1,11 +1,11 @@
 package cafesat
 package theories.adt
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
-class AdtSolverIntsTests extends FlatSpec with AdtSolverSpecHelpers {
+class AdtSolverIntsTests extends AnyFlatSpec with AdtSolverSpecHelpers {
 
   trait SIntSig extends FreshSolver {
     def Succ(pred: Term) = Constructor(0,0,List(pred))

--- a/src/test/scala/cafesat/theories/adt/AdtSolverListsTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverListsTests.scala
@@ -127,13 +127,13 @@ class AdtSolverListsTests extends AnyFlatSpec with BeforeAndAfter with AdtSolver
     val x = Variable(1)
     override val eqs = Seq( (Head(x), Fina) )
     override val ineqs = Seq( (Head(x), Fina) )
-    assertUnsatDueTo[InvalidEquality]
+    assertUnsatDueTo[InvalidEquality]()
   }
   it should "return unsat on simple selector inequality" in new FiniteAndListSig {
     val x = Variable(1)
     override val eqs = Seq( (x, Cons(Fina,Nil)) )
     override val ineqs = Seq( (Head(x), Fina) )
-    assertUnsatDueTo[InvalidEquality]
+    assertUnsatDueTo[InvalidEquality]()
   }
   it should "return sat on list equality with selectors" in new FiniteAndListSig {
     val x = Variable(1)

--- a/src/test/scala/cafesat/theories/adt/AdtSolverListsTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverListsTests.scala
@@ -2,10 +2,11 @@ package cafesat
 package theories.adt
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
-class AdtSolverListsTests extends FlatSpec with BeforeAndAfter with AdtSolverSpecHelpers {
+class AdtSolverListsTests extends AnyFlatSpec with BeforeAndAfter with AdtSolverSpecHelpers {
 
   //TODO: could be useful to have that for debugging
   //private var _currentTestName: String = "<Unset>"

--- a/src/test/scala/cafesat/theories/adt/AdtSolverMultiConstructorsTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverMultiConstructorsTests.scala
@@ -1,11 +1,11 @@
 package cafesat
 package theories.adt
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
-class AdtSolverMultiConstructorsTests extends FlatSpec with AdtSolverSpecHelpers {
+class AdtSolverMultiConstructorsTests extends AnyFlatSpec with AdtSolverSpecHelpers {
 
   import Types._
 

--- a/src/test/scala/cafesat/theories/adt/AdtSolverNullConstructorsTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverNullConstructorsTests.scala
@@ -1,14 +1,14 @@
 package cafesat
 package theories.adt
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
 /**
  * Created by gs on 14.05.15.
  */
-class AdtSolverNullConstructorsTests extends FlatSpec with AdtSolverSpecHelpers {
+class AdtSolverNullConstructorsTests extends AnyFlatSpec with AdtSolverSpecHelpers {
 
   import Types._
 

--- a/src/test/scala/cafesat/theories/adt/AdtSolverSignaturesTests.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverSignaturesTests.scala
@@ -1,11 +1,11 @@
 package cafesat
 package theories.adt
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
-class AdtSolverSignaturesTests extends FlatSpec {
+class AdtSolverSignaturesTests extends AnyFlatSpec {
 
 
   "Enum ADT" should "have a well-founded signature" in {

--- a/src/test/scala/cafesat/theories/adt/AdtSolverSpecHelpers.scala
+++ b/src/test/scala/cafesat/theories/adt/AdtSolverSpecHelpers.scala
@@ -2,11 +2,12 @@ package cafesat
 package theories.adt
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.reflect.ClassTag
 
 trait AdtSolverSpecHelpers {
-  this: FlatSpec =>
+  this: AnyFlatSpec =>
 
   import Types._
 


### PR DESCRIPTION
This is a part of the cleanups I did to get the library to work with Scala 2.13 in the Renaissance benchmark suite. I don't have the changes in separate branches, but I at least tried to keep similar changes in a single changeset, so feel free to pick anything useful.